### PR TITLE
fix: print `abstract` modifier once and with proper spaces

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -841,6 +841,19 @@ public class TestSniperPrinter {
 		testSniper("sniperPrinter.SpaceAfterFinal", modifyField, assertContainsSpaceAfterFinal);
 	}
 
+	@Test
+	void testAbstractShouldBePrintedOnceAndWithProperSpacing() {
+		Consumer<CtType<?>> noOpModifyStaticClass = type -> {
+			CtType<?> staticClass = type.filterChildren(CtType.class::isInstance).first();
+			staticClass.descendantIterator().forEachRemaining(TestSniperPrinter::markElementForSniperPrinting);
+		};
+
+		BiConsumer<CtType<?>, String> assertDoesNotContainDiff = (type, result) ->
+					assertThat(result, not(containsString("abstractstatic abstract class AbstractFoo")));
+
+		testSniper("sniperPrinter.PrintAbstractOnceWithProperSpacing", noOpModifyStaticClass, assertDoesNotContainDiff);
+	}
+
 	/**
 	 * 1) Runs spoon using sniper mode,
 	 * 2) runs `typeChanger` to modify the code,

--- a/src/test/resources/sniperPrinter/PrintAbstractOnceWithProperSpacing.java
+++ b/src/test/resources/sniperPrinter/PrintAbstractOnceWithProperSpacing.java
@@ -1,0 +1,8 @@
+package sniperPrinter;
+
+public class PrintAbstractOnceWithProperSpacing {
+    static abstract class AbstractFoo
+    {
+
+    }
+}


### PR DESCRIPTION
Copy of INRIA/spoon:4318